### PR TITLE
Correct text for the route services feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,9 @@
                 </p>
                 <h2 class="bold-medium">Cloud Foundry Route Services</h2>
                 <p>
-                  The Cloud Foundry command line client has an option to enable you to connect directly to the virtual machines on which your apps run using cf ssh. <a href="https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html">(See the Cloud Foundry documentation on accessing apps with SSH [external link].</a>
-
-                  This functionality is currently disabled on the Government PaaS. We intend to make it available in future, following security testing.
+                  Cloud Foundry has a feature called <a href="https://docs.cloudfoundry.org/services/route-services.html">route services</a>. This allows you to filter and transform requests before they reach application instances.
+                    
+                  At present we don't know of any use cases for this feature amongst our users. If you would like to use it, please contact our support team at <a href="mailto:gov-uk-paas-support@digital.cabinet-office.gov.uk">gov-uk-paas-support@digital.cabinet-office.gov.uk</a>, providing details of what you would like to use it for.
                 </p>
         </div>
         <div class="grid-row">


### PR DESCRIPTION
## What

Previously the text for the route services feature actually referred to the use of cf ssh.

Added some text explaining briefly what route services are and what to do if you think you need them

## How to review

Read, check it makes sense. Merge. It will be deployed on the next prod deploy.

## Who can review

Anyone but @bleach and Jess